### PR TITLE
Fix Buffer constructor deprecation warning on v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "postgres-bytea",
   "main": "index.js",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Postgres bytea parser",
   "license": "MIT",
   "repository": "bendrucker/postgres-bytea",


### PR DESCRIPTION
i.e. for users of pg 8.x and earlier with the default pg-types dependency. https://github.com/brianc/node-postgres/issues/2426#issuecomment-3662496826

(There’s no branch for v1 right now, but if you’re interested in merging this, the target branch can be changed once it’s created.)